### PR TITLE
fix: Use check-manifest v0.42 directory ignore pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ exclude = '''
 
 [tool.check-manifest]
 ignore = [
-    'examples*',
-    'tests*',
-    'binder*',
+    'examples/**',
+    'tests/**',
+    'binder/**',
     '.*',
     'pyproject.toml',
     'pytest.ini',


### PR DESCRIPTION
Use the new directory ignore pattern of `check-manifest` introduced in [`v0.42`](https://github.com/mgedmin/check-manifest/blob/master/CHANGES.rst#042-2020-05-03).

> You can ignore directories only by ignoring every file inside it. You can use `--ignore=dir/**` to do that

```
* Use check-manifest ignore pattern introduced in v0.42
```