### PR TITLE
chore: Migrate metadata and setup options from setup.py to setup.cfg 

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,6 +3,6 @@ current_version = 0.0.1
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
+[bumpversion:file:setup.cfg]
 
 [bumpversion:file:src/pymela/version.py]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,55 @@
+[metadata]
+name = pymela
+version = 0.0.1
+description = Pure-Python Matrix Element Likelihood Analysis
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/scailfin/pyMELA
+author = Matthew Feickert
+author_email = matthew.feickert@cern.ch
+license = Apache
+license_file = LICENSE
+keywords = python physics matrix-element
+project_urls =
+    Documentation = https://scailfin.github.io/pyMELA/
+    Source = https://github.com/scailfin/pyMELA
+    Tracker = https://github.com/scailfin/pyMELA/issues
+classifiers =
+    Development Status :: 3 - Alpha
+    License :: OSI Approved :: Apache Software License
+    Intended Audience :: Science/Research
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Physics
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
 [bdist_wheel]
 universal = 1
 
-[metadata]
-license_file = LICENSE
+[options]
+setup_requires =
+    setuptools_scm>=1.15.0
+    setuptools_scm_git_archive>=1.0
+package_dir =
+    = src
+packages = find:
+include_package_data = True
+python_requires = >=3.6
+install_requires =
+    click>=6.0
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    pymela = pymela.commandline:pymela
+
+[build_sphinx]
+project = pymela
+source-dir = docs
+build-dir = docs/_build
+all-files = 1
+warning-is-error = 1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 extras_require = {
     "develop": [
         "check-manifest",
-        "pytest~=5.2",
+        "pytest~=6.0",
         "pytest-cov~=2.8",
         "pytest-console-scripts~=0.2",
         "bumpversion~=0.5",

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
-from setuptools import setup, find_packages
-from os import path
-
-this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, "README.md"), encoding="utf-8") as readme_md:
-    long_description = readme_md.read()
+from setuptools import setup
 
 extras_require = {
     "develop": [
@@ -20,28 +15,4 @@ extras_require = {
 }
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
 
-setup(
-    name="pymela",
-    version="0.0.1",
-    description="Pure-Python Matrix Element Likelihood Analysis",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/scailfin/pyMELA",
-    author="Matthew Feickert",
-    author_email="matthew.feickert@cern.ch",
-    license="Apache",
-    keywords="python physics matrix-element",
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-    ],
-    package_dir={"": "src"},
-    packages=find_packages(where="src"),
-    include_package_data=True,
-    install_requires=["click>=6.0"],
-    python_requires=">=3.6",
-    extras_require=extras_require,
-    entry_points={"console_scripts": ["pymela=pymela.commandline:pymela"]},
-)
+setup(extras_require=extras_require)


### PR DESCRIPTION
Use `setup.cfg` as the main source of configuration and install information by migrating metadata and setup options from `setup.py` to `setup.cfg`.

```
* Move PyPI metadata from setup.py to setup.cfg
* Move setup options from setup.py to setup.cfg
* Update bumpversion.cfg file list
```