### PR TITLE
ci: Use pip with 2020 dependency resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -q --no-cache-dir -e .[complete]
+        pip install --ignore-installed -q --no-cache-dir --use-feature=2020-resolver -e .[test]
         pip list
     - name: Check MANIFEST
       if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[lint]
+        python -m pip install --ignore-installed -q --no-cache-dir --use-feature=2020-resolver -e .[lint]
         python -m pip list
     - name: Lint with Pyflakes
       run: |


### PR DESCRIPTION
With the [release of `pip` `v20.2`](https://discuss.python.org/t/announcement-pip-20-2-release/4863) came the introduction of the beta release of the [2020 dependency resolver](https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-2-2020) that can be enabled with the `--use-feature=2020-resolver` flag.

This PR adopts the use of the `pip` October 2020 dependency resolver for early adoption and testing


```
* Use --use-feature=2020-resolver flag with pip when installing dependencies
   - c.f. https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-2-2020
* Use the 'test' extra for CI workflow
```