### PR TITLE
feat: Add Dockerfile and Docker publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,29 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
+
+  docker:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Docker image
+      uses: docker/build-push-action@v1
+      with:
+        repository: scailfin/pymela
+        dockerfile: docker/Dockerfile
+        tags: test
+        tag_with_sha: true
+        tag_with_ref: true
+        push: false
+    - name: List built images
+      run: docker images
+    - name: Run CLI API check
+      run: |
+        printf "\npymela\n"
+        docker run --rm scailfin/pymela:test
+        printf "\npymela --version\n"
+        docker run --rm scailfin/pymela:test --version
+        printf "\npymela --help\n"
+        docker run --rm scailfin/pymela:test --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,3 +26,7 @@ jobs:
     - name: Lint with Black
       run: |
         black --check --diff --verbose .
+    - name: Lint Dockerfile
+      uses: brpaz/hadolint-action@v1.1.0
+      with:
+        dockerfile: "docker/Dockerfile"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,35 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+
+jobs:
+  build-and-publish:
+    name: Build and publish Docker images to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build and Publish to Registry
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: scailfin/pymela
+        dockerfile: docker/Dockerfile
+        tags: latest
+    - name: Build and Publish to Registry with Release Tag
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: scailfin/pymela
+        dockerfile: docker/Dockerfile
+        tags: latest,latest-stable
+        tag_with_ref: true

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,2 @@
+ignored:
+  - DL3008 # Pin versions in apt get install

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at lukas.heinrich@cern.ch. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at matthew.feickert@cern.ch. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.md
+++ b/README.md
@@ -13,5 +13,7 @@ Pure-Python Matrix Element Likelihood Analysis
 
 [![PyPI version](https://badge.fury.io/py/pymela.svg)](https://badge.fury.io/py/pymela)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/pymela.svg)](https://pypi.org/project/pymela/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/scailfin/pymela)](https://hub.docker.com/r/scailfin/pymela)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/scailfin/pymela/latest)](https://hub.docker.com/r/scailfin/pymela/tags?name=latest)
 
 pyMELA provides matrix element analysis tools that are accelerated using machine learning.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,4 +24,4 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local /usr/local
-ENTRYPOINT ["/usr/local/bin/pymela"]
+ENTRYPOINT ["pymela"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,27 @@
+ARG BASE_IMAGE=python:3.8-slim
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE} as base
+
+FROM base as builder
+COPY . /code
+# hadolint ignore=DL3003
+RUN apt-get -qq -y update && \
+    apt-get -qq -y install --no-install-recommends \
+        git && \
+    apt-get -y autoclean && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt/lists/* && \
+    cd /code && \
+    python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
+    python -m pip install --no-cache-dir . && \
+    python -m pip list
+
+FROM base
+RUN apt-get -qq -y update && \
+    apt-get -qq -y install --no-install-recommends \
+        curl && \
+    apt-get -y autoclean && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local /usr/local
+ENTRYPOINT ["/usr/local/bin/pymela"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,10 @@ exclude = '''
 
 [tool.check-manifest]
 ignore = [
-    'examples/**',
-    'tests/**',
-    'binder/**',
+    'examples*',
+    'tests*',
+    'docker*',
+    'binder*',
     '.*',
     'pyproject.toml',
     'pytest.ini',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ exclude = '''
 
 [tool.check-manifest]
 ignore = [
-    'examples*',
-    'tests*',
-    'docker*',
-    'binder*',
+    'examples/*',
+    'tests/*',
+    'docker/*',
+    'binder/*',
     '.*',
     'pyproject.toml',
     'pytest.ini',


### PR DESCRIPTION
Add a `Dockerfile` to capture `pymela` state and publish to Docker Hub and additionally add a testing and publishing workflow. Additionally lint the `Dockerfile`

```
* Add Dockerfile
* Add test build of Docker image to CI workflow
* Add lint of Dockerfile with Hadolint to lint workflow
* Add Hadolint config file
* Add publishing of Docker image to Docker Hub
* Ignore Dockerfile from MANIFEST
```