### PR TITLE
feat: Set SCAILFIN MadGraph5_aMC-NLO Docker image as base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE=python:3.8-slim
-docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.7.0-python3
+ARG BASE_IMAGE=scailfin/madgraph5-amc-nlo:mg5_amc2.7.0-python3
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
 ARG BASE_IMAGE=python:3.8-slim
+docker pull scailfin/madgraph5-amc-nlo:mg5_amc2.7.0-python3
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 


### PR DESCRIPTION
Set the [SCAILFIN MadGraph5_aMC-NLO Docker image](https://github.com/scailfin/MadGraph5_aMC-NLO) as the base image for pyMELA's Docker image.

```
* Set base Docker image to scailfin/madgraph5-amc-nlo:mg5_amc2.7.0-python3
```