### PR TITLE
feat: Use MadGraph5 v2.8.1 image as base Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=scailfin/madgraph5-amc-nlo:mg5_amc2.7.0-python3
+ARG BASE_IMAGE=scailfin/madgraph5-amc-nlo:mg5_amc2.8.1
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 


### PR DESCRIPTION
Update to use the latest working Docker image as the base image

```
* Use SCAILFIN MadGraph5 v2.8.1 Docker image as base image for pyMELA
   - c.f. https://github.com/scailfin/MadGraph5_aMC-NLO
```